### PR TITLE
CRM-17307 & CRM-17654

### DIFF
--- a/CRM/Report/Form/Contact/Relationship.php
+++ b/CRM/Report/Form/Contact/Relationship.php
@@ -479,7 +479,7 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
         //for displaying relationship type filter
         if ($value['title'] == 'Relationship') {
           $relTypes = CRM_Core_PseudoConstant::relationshipType();
-          $op = CRM_Utils_array::value('relationship_type_id_op', $this->_params) == 'in' ? 
+          $op = CRM_Utils_array::value('relationship_type_id_op', $this->_params) == 'in' ?
             ts('Is one of') . ' ' : ts('Is not one of') . ' ';
           $relationshipTypes = array();
           foreach ($this->_params['relationship_type_id_value'] as $relationship) {

--- a/CRM/Report/Form/Contact/Relationship.php
+++ b/CRM/Report/Form/Contact/Relationship.php
@@ -479,7 +479,8 @@ class CRM_Report_Form_Contact_Relationship extends CRM_Report_Form {
         //for displaying relationship type filter
         if ($value['title'] == 'Relationship') {
           $relTypes = CRM_Core_PseudoConstant::relationshipType();
-          $op = 'Is one of ';
+          $op = CRM_Utils_array::value('relationship_type_id_op', $this->_params) == 'in' ? 
+            ts('Is one of') . ' ' : ts('Is not one of') . ' ';
           $relationshipTypes = array();
           foreach ($this->_params['relationship_type_id_value'] as $relationship) {
             $relationshipTypes[] = $relTypes[$relationship]['label_' . $this->relationType];

--- a/ang/crmMailing/FromAddress.js
+++ b/ang/crmMailing/FromAddress.js
@@ -18,6 +18,7 @@
           var addr = crmFromAddresses.getByLabel(newValue);
           mailing.from_name = addr.author;
           mailing.from_email = addr.email;
+          mailing.replyto_email = addr.email;
         });
         // FIXME: Shouldn't we also be watching mailing.from_name and mailing.from_email?
       }


### PR DESCRIPTION
@eileenmcnaughton These were in 2 separate PRs but joined them for fuzion's case

CRM - 17307 ensures when you re-use a CiviMail that if you change the from email the reply-to address also changes

CRM-17654 was a request from Chris Maltby to allow for having multiple relationship types being used in the relationship report. Both have gone into Civi in 4.7 but feel they are fine in 4.6 as well. 
