### PR TITLE
CRM-17693 Increase default string table size to be 255. 255 Character…

### DIFF
--- a/CRM/Export/BAO/Export.php
+++ b/CRM/Export/BAO/Export.php
@@ -1348,7 +1348,7 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
             $sqlColumns[$fieldName] = "$fieldName varchar({$query->_fields[$field]['maxlength']})";
           }
           else {
-            $sqlColumns[$fieldName] = "$fieldName varchar(64)";
+            $sqlColumns[$fieldName] = "$fieldName varchar(255)";
           }
           break;
 
@@ -1423,12 +1423,12 @@ INSERT INTO {$componentTable} SELECT distinct gc.contact_id FROM civicrm_group_c
                 break;
 
               default:
-                $sqlColumns[$fieldName] = "$fieldName varchar(64)";
+                $sqlColumns[$fieldName] = "$fieldName varchar(255)";
                 break;
             }
           }
           else {
-            $sqlColumns[$fieldName] = "$fieldName varchar(64)";
+            $sqlColumns[$fieldName] = "$fieldName varchar(255)";
           }
         }
       }


### PR DESCRIPTION
…s seems fairly common on the db and matches max length of contribution page title

Increase Default sizes to 255
